### PR TITLE
MUS-164 Fixed stem bug in drawing accords

### DIFF
--- a/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/draw/NoteDrawerTest.java
+++ b/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/draw/NoteDrawerTest.java
@@ -169,4 +169,21 @@ public class NoteDrawerTest extends AbstractDrawerTest {
         assertCanvasElementQueueSize(stemCount + crossCount + helpLinesCount + bodyCount);
         clearCanvasElementQueue();
     }
+
+    public void testIsStemInCenter() {
+        NoteSymbol noteSymbol = NoteSymbolTestDataFactory.createNoteSymbol(NoteName.C5, NoteName.D5);
+        noteDrawer.drawSymbol(noteSymbol);
+
+        assertTrue(noteSymbol.isStemInCenter());
+        clearCanvasElementQueue();
+    }
+
+    public void testIsStemInCenterFalse() {
+        NoteSymbol noteSymbol = NoteSymbolTestDataFactory.createNoteSymbol(NoteName.C5, NoteName.F5);
+        noteDrawer.drawSymbol(noteSymbol);
+
+        assertFalse(noteSymbol.isStemInCenter());
+        clearCanvasElementQueue();
+    }
+
 }

--- a/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/symbol/NoteSymbolTest.java
+++ b/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/symbol/NoteSymbolTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.musicdroid.pocketmusic.test.note.symbol;
 
 import android.graphics.RectF;
+import android.provider.ContactsContract;
 import android.test.AndroidTestCase;
 
 import org.catrobat.musicdroid.pocketmusic.note.MusicalKey;
@@ -184,5 +185,13 @@ public class NoteSymbolTest extends AndroidTestCase {
         NoteSymbol noteSymbol = NoteSymbolTestDataFactory.createNoteSymbol(NoteName.C5, NoteName.C5);
 
         assertFalse(noteSymbol.isStemUp(MusicalKey.VIOLIN));
+    }
+
+    public void testGetStemShift() {
+        NoteSymbol noteSymbol = NoteSymbolTestDataFactory.createNoteSymbol(NoteName.C5, NoteName.D5);
+        noteSymbol.setStemInCenter();
+        float expectedShift = 20;
+
+        assertEquals(noteSymbol.getStemShift(20, MusicalKey.VIOLIN), expectedShift);
     }
 }

--- a/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/symbol/SymbolPositionTest.java
+++ b/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/note/symbol/SymbolPositionTest.java
@@ -101,4 +101,13 @@ public class SymbolPositionTest extends AndroidTestCase {
 
         assertEquals(rect, symbolPosition.toRectF());
     }
+
+    public void testGetCenterOfSymbolPosition() {
+        RectF rect = new RectF(0, 0, 100, 100);
+        SymbolPosition symbolPosition = new SymbolPosition(rect);
+
+        float expectedCenter = 50;
+
+        assertEquals(expectedCenter, symbolPosition.getCenterOfRect());
+    }
 }

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/draw/NoteBodyDrawer.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/draw/NoteBodyDrawer.java
@@ -80,6 +80,7 @@ public final class NoteBodyDrawer {
                         prevNoteName, noteName));
 
                 if (differenceBetweenNotesInHalfTones == 1) {
+                    noteSymbol.setStemInCenter();
                     if (isStemUpdirected) {
                         right += 2 * noteWidth;
                         left += 2 * noteWidth;

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/draw/NoteStemDrawer.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/draw/NoteStemDrawer.java
@@ -52,16 +52,16 @@ public class NoteStemDrawer {
         PointF endPointOfNoteStem = new PointF();
 
         if (noteSymbol.isStemUp(key)) {
-            stemRect.left = symbolPosition.getRight();
-            stemRect.right = symbolPosition.getRight();
+            stemRect.left = symbolPosition.getRight() + noteSymbol.getStemShift(symbolPosition.getCenterOfRect(), key);
+            stemRect.right = symbolPosition.getRight() + noteSymbol.getStemShift(symbolPosition.getCenterOfRect(), key);
             stemRect.bottom = symbolPosition.getBottom() - distanceBetweenLinesHalf;
             stemRect.top = symbolPosition.getTop() - stemLength;
 
             endPointOfNoteStem.x = stemRect.left;
             endPointOfNoteStem.y = stemRect.top;
         } else {
-            stemRect.left = symbolPosition.getLeft();
-            stemRect.right = symbolPosition.getLeft();
+            stemRect.left = symbolPosition.getLeft() + noteSymbol.getStemShift(symbolPosition.getCenterOfRect(), key);
+            stemRect.right = symbolPosition.getLeft() + noteSymbol.getStemShift(symbolPosition.getCenterOfRect(), key);
             stemRect.top = symbolPosition.getTop() + distanceBetweenLinesHalf;
             stemRect.bottom = symbolPosition.getBottom() + stemLength;
 

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/symbol/NoteSymbol.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/symbol/NoteSymbol.java
@@ -37,9 +37,12 @@ public class NoteSymbol extends Symbol {
 
     private Map<NoteName, NoteLength> notes;
 
+    private boolean IsStemInCenter;
+
     public NoteSymbol() {
         notes = new HashMap<NoteName, NoteLength>();
-    }
+        IsStemInCenter = false;
+     }
 
     public void addNote(NoteName noteName, NoteLength noteLength) {
         notes.put(noteName, noteLength);
@@ -110,6 +113,25 @@ public class NoteSymbol extends Symbol {
         }
 
         return false;
+    }
+
+    public void setStemInCenter() {
+       this.IsStemInCenter = true;
+    }
+
+    public float getStemShift(float centerOfSymbolPosition, MusicalKey key) {
+        if(this.isStemInCenter()) {
+            if(this.isStemUp(key)) {
+               return centerOfSymbolPosition * (-1) ;
+            } else {
+                return centerOfSymbolPosition;
+            }
+        }
+        return 0;
+    }
+
+    public boolean isStemInCenter() {
+        return  this.IsStemInCenter;
     }
 
     public NoteFlag getFlag() {

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/symbol/SymbolPosition.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/note/symbol/SymbolPosition.java
@@ -93,6 +93,8 @@ public class SymbolPosition implements Serializable {
         return new RectF(getLeft(), getTop(), getRight(), getBottom());
     }
 
+    public float getCenterOfRect() { return (getRight() - getLeft())/2;}
+
     @Override
     public boolean equals(Object obj) {
         if ((obj == null) || !(obj instanceof SymbolPosition)) {


### PR DESCRIPTION
If there are notes which have to be moved because they would otherwise
overlap the stem has to be moved to the center of the notes.
