### PR TITLE
MUS-152 Make use of Gradientdrawable, Refactor test

### DIFF
--- a/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/instrument/piano/PianoViewFragmentTest.java
+++ b/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/instrument/piano/PianoViewFragmentTest.java
@@ -68,8 +68,8 @@ public class PianoViewFragmentTest extends ActivityInstrumentationTestCase2<Pian
         for (int i = 0; i < pianoViewFragment.getWhiteButtonCount(); i++)
             assertEquals(pianoViewFragment.getWhiteButtonAtIndex(i).getWidth(), buttonWidth - whiteButtonMargin);
 
-        assertEquals(((buttonWidth + blackButtonMargin)/ 2), pianoViewFragment.getBlackButtonAtIndex(0).getLeft());
-        assertEquals((((3*buttonWidth) + blackButtonMargin) / 2), pianoViewFragment.getBlackButtonAtIndex(1).getLeft());
+        assertEquals(((buttonWidth + blackButtonMargin) / 2), pianoViewFragment.getBlackButtonAtIndex(0).getLeft());
+        assertEquals(((3 * buttonWidth) + blackButtonMargin) / 2, pianoViewFragment.getBlackButtonAtIndex(1).getLeft());
 
         assertEquals(0, pianoViewFragment.getWhiteButtonAtIndex(0).getLeft());
         assertEquals(buttonWidth, pianoViewFragment.getWhiteButtonAtIndex(1).getLeft());

--- a/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/instrument/piano/PianoViewFragmentTest.java
+++ b/musicdroid/src/androidTest/java/org/catrobat/musicdroid/pocketmusic/test/instrument/piano/PianoViewFragmentTest.java
@@ -27,6 +27,7 @@ import android.test.ActivityInstrumentationTestCase2;
 import android.test.UiThreadTest;
 import android.widget.Button;
 
+import org.catrobat.musicdroid.pocketmusic.R;
 import org.catrobat.musicdroid.pocketmusic.instrument.piano.PianoActivity;
 import org.catrobat.musicdroid.pocketmusic.instrument.piano.PianoViewFragment;
 import org.catrobat.musicdroid.pocketmusic.tools.DisplayMeasurements;
@@ -59,14 +60,16 @@ public class PianoViewFragmentTest extends ActivityInstrumentationTestCase2<Pian
     private void assertButtonPosition(int keyWidthScaleFactor, int keysPerOctave) {
         DisplayMeasurements displayMeasurements = new DisplayMeasurements(getActivity());
         int buttonWidth = displayMeasurements.getDisplayWidth() / (keysPerOctave + keyWidthScaleFactor);
+        int whiteButtonMargin = pianoViewFragment.getActivity().getResources().getDimensionPixelSize(R.dimen.white_button_margin);
+        int blackButtonMargin = pianoViewFragment.getActivity().getResources().getDimensionPixelSize(R.dimen.black_button_margin);
 
         for (int i = 0; i < pianoViewFragment.getBlackButtonCount(); i++)
-            assertEquals(pianoViewFragment.getBlackButtonAtIndex(i).getWidth(), buttonWidth);
+            assertEquals(pianoViewFragment.getBlackButtonAtIndex(i).getWidth(), buttonWidth - blackButtonMargin);
         for (int i = 0; i < pianoViewFragment.getWhiteButtonCount(); i++)
-            assertEquals(pianoViewFragment.getWhiteButtonAtIndex(i).getWidth(), buttonWidth);
+            assertEquals(pianoViewFragment.getWhiteButtonAtIndex(i).getWidth(), buttonWidth - whiteButtonMargin);
 
-        assertEquals((buttonWidth / 2), pianoViewFragment.getBlackButtonAtIndex(0).getLeft());
-        assertEquals((buttonWidth / 2 * 3), pianoViewFragment.getBlackButtonAtIndex(1).getLeft());
+        assertEquals(((buttonWidth + blackButtonMargin)/ 2), pianoViewFragment.getBlackButtonAtIndex(0).getLeft());
+        assertEquals((((3*buttonWidth) + blackButtonMargin) / 2), pianoViewFragment.getBlackButtonAtIndex(1).getLeft());
 
         assertEquals(0, pianoViewFragment.getWhiteButtonAtIndex(0).getLeft());
         assertEquals(buttonWidth, pianoViewFragment.getWhiteButtonAtIndex(1).getLeft());

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/instrument/piano/PianoViewFragment.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/instrument/piano/PianoViewFragment.java
@@ -103,28 +103,25 @@ public class PianoViewFragment extends Fragment {
         int buttonWidth = displayMeasurements.getDisplayWidth() / (Octave.NUMBER_OF_UNSIGNED_HALF_TONE_STEPS_PER_OCTAVE + pianoKeyWidthScaleFactor);
 
         int blackButtonMargin = getResources().getDimensionPixelSize(R.dimen.black_button_margin);
-        int blackButtonWidth = buttonWidth - blackButtonMargin;
+        int whiteButtonMargin = getResources().getDimensionPixelSize(R.dimen.white_button_margin);
 
         for (int i = 0; i < blackButtons.size(); i++) {
             RelativeLayout.LayoutParams black_button_rlp = new RelativeLayout.LayoutParams(
-                    blackButtonWidth,
+                    buttonWidth - blackButtonMargin,
                     displayMeasurements.getDisplayHeight() / pianoBlackKeyHeightScaleFactor
             );
 
-            black_button_rlp.setMargins((blackButtonWidth / 2) * ((i * 2) + 1) + (i + 1) * blackButtonMargin, 0, 0, 0);
+            black_button_rlp.setMargins(((((i * 2) + 1) * buttonWidth) + blackButtonMargin) / 2, 0, 0, 0);
             blackButtons.get(i).setLayoutParams(black_button_rlp);
         }
 
-        int whiteButtonMargin = getResources().getDimensionPixelSize(R.dimen.white_button_margin);
-        int whiteButtonWidth = buttonWidth - whiteButtonMargin;
-
         for (int i = 0; i < whiteButtons.size(); i++) {
             RelativeLayout.LayoutParams whiteButtonRlp = new RelativeLayout.LayoutParams(
-                    whiteButtonWidth,
+                    buttonWidth - whiteButtonMargin,
                     RelativeLayout.LayoutParams.MATCH_PARENT
             );
 
-            whiteButtonRlp.setMargins(whiteButtonWidth * i + whiteButtonMargin * i, 0, 0, 0);
+            whiteButtonRlp.setMargins(buttonWidth * i, 0, 0, 0);
             whiteButtons.get(i).setLayoutParams(whiteButtonRlp);
         }
     }

--- a/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/instrument/piano/PianoViewFragment.java
+++ b/musicdroid/src/main/java/org/catrobat/musicdroid/pocketmusic/instrument/piano/PianoViewFragment.java
@@ -102,28 +102,30 @@ public class PianoViewFragment extends Fragment {
 
         int buttonWidth = displayMeasurements.getDisplayWidth() / (Octave.NUMBER_OF_UNSIGNED_HALF_TONE_STEPS_PER_OCTAVE + pianoKeyWidthScaleFactor);
 
-        ArrayList<RelativeLayout.LayoutParams> blackKeyLayoutParams = new ArrayList<>();
-        ArrayList<RelativeLayout.LayoutParams> whiteKeyLayoutParams = new ArrayList<>();
-
+        int blackButtonMargin = getResources().getDimensionPixelSize(R.dimen.black_button_margin);
+        int blackButtonWidth = buttonWidth - blackButtonMargin;
 
         for (int i = 0; i < blackButtons.size(); i++) {
-            blackKeyLayoutParams.add(new RelativeLayout.LayoutParams(
-                    buttonWidth,
+            RelativeLayout.LayoutParams black_button_rlp = new RelativeLayout.LayoutParams(
+                    blackButtonWidth,
                     displayMeasurements.getDisplayHeight() / pianoBlackKeyHeightScaleFactor
-            ));
+            );
 
-            blackKeyLayoutParams.get(i).setMargins((buttonWidth / 2) * ((i * 2) + 1), 0, 0, 0);
-            blackButtons.get(i).setLayoutParams(blackKeyLayoutParams.get(i));
+            black_button_rlp.setMargins((blackButtonWidth / 2) * ((i * 2) + 1) + (i + 1) * blackButtonMargin, 0, 0, 0);
+            blackButtons.get(i).setLayoutParams(black_button_rlp);
         }
 
-        for (int i = 0; i < whiteButtons.size(); i++) {
-            whiteKeyLayoutParams.add(new RelativeLayout.LayoutParams(
-                    buttonWidth,
-                    RelativeLayout.LayoutParams.MATCH_PARENT
-            ));
+        int whiteButtonMargin = getResources().getDimensionPixelSize(R.dimen.white_button_margin);
+        int whiteButtonWidth = buttonWidth - whiteButtonMargin;
 
-            whiteKeyLayoutParams.get(i).setMargins(buttonWidth * i, 0, 0, 0);
-            whiteButtons.get(i).setLayoutParams(whiteKeyLayoutParams.get(i));
+        for (int i = 0; i < whiteButtons.size(); i++) {
+            RelativeLayout.LayoutParams whiteButtonRlp = new RelativeLayout.LayoutParams(
+                    whiteButtonWidth,
+                    RelativeLayout.LayoutParams.MATCH_PARENT
+            );
+
+            whiteButtonRlp.setMargins(whiteButtonWidth * i + whiteButtonMargin * i, 0, 0, 0);
+            whiteButtons.get(i).setLayoutParams(whiteButtonRlp);
         }
     }
 
@@ -138,14 +140,12 @@ public class PianoViewFragment extends Fragment {
             public boolean onTouch(View view, MotionEvent event) {
                 final Octave octave = ((PianoActivity) getActivity()).getOctave();
                 if (isDownActionEvent(event)) {
-                    view.setX(view.getX() + 5);
                     addKeyPress(new NoteEvent(octave.getNoteNames()[index], true));
                 } else if (isUpActionEvent(event)) {
-                    view.setX(view.getX() - 5);
                     addKeyPress(new NoteEvent(octave.getNoteNames()[index], false));
                 }
 
-                return true;
+                return false;
             }
 
             private boolean isDownActionEvent(MotionEvent event) {

--- a/musicdroid/src/main/res/drawable/black_gradient_drawable.xml
+++ b/musicdroid/src/main/res/drawable/black_gradient_drawable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Musicdroid: An on-device music generator for Android
-  ~ Copyright (C) 2010-2014 The Catrobat Team
+  ~ Copyright (C) 2010-2015 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -20,14 +20,11 @@
   ~
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
--->
-<resources>
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="dialog_item_margin" >16dp</dimen >
-    <dimen name="dialog_item_edittext_margin" >12dp</dimen >
-    <dimen name="dialog_margin" >16dp</dimen >
-    <dimen name="dialog_item_height" >48dp</dimen >
-    <dimen name="white_button_margin" >1dp</dimen >
-    <dimen name="black_button_margin" >6dp</dimen >
-</resources>
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+    <gradient android:angle="90"
+        android:type="linear"
+        android:startColor="@android:color/darker_gray"
+        android:endColor="@android:color/black"/>
+</shape>

--- a/musicdroid/src/main/res/drawable/black_selector.xml
+++ b/musicdroid/src/main/res/drawable/black_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Musicdroid: An on-device music generator for Android
-  ~ Copyright (C) 2010-2014 The Catrobat Team
+  ~ Copyright (C) 2010-2015 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -20,14 +20,9 @@
   ~
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
--->
-<resources>
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="dialog_item_margin" >16dp</dimen >
-    <dimen name="dialog_item_edittext_margin" >12dp</dimen >
-    <dimen name="dialog_margin" >16dp</dimen >
-    <dimen name="dialog_item_height" >48dp</dimen >
-    <dimen name="white_button_margin" >1dp</dimen >
-    <dimen name="black_button_margin" >6dp</dimen >
-</resources>
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item  android:drawable="@drawable/black_gradient_drawable" android:state_pressed="true"/>
+    <item android:drawable="@android:color/black"/>
+</selector>

--- a/musicdroid/src/main/res/drawable/white_gradient_drawable.xml
+++ b/musicdroid/src/main/res/drawable/white_gradient_drawable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Musicdroid: An on-device music generator for Android
-  ~ Copyright (C) 2010-2014 The Catrobat Team
+  ~ Copyright (C) 2010-2015 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -20,14 +20,11 @@
   ~
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
--->
-<resources>
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="dialog_item_margin" >16dp</dimen >
-    <dimen name="dialog_item_edittext_margin" >12dp</dimen >
-    <dimen name="dialog_margin" >16dp</dimen >
-    <dimen name="dialog_item_height" >48dp</dimen >
-    <dimen name="white_button_margin" >1dp</dimen >
-    <dimen name="black_button_margin" >6dp</dimen >
-</resources>
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+    <gradient android:angle="90"
+        android:type="linear"
+        android:startColor="@android:color/darker_gray"
+        android:endColor="@android:color/white"/>
+</shape>

--- a/musicdroid/src/main/res/drawable/white_selector.xml
+++ b/musicdroid/src/main/res/drawable/white_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/white_gradient_drawable" android:state_pressed="true" />
+    <item android:drawable="@android:color/white"/>
+</selector>

--- a/musicdroid/src/main/res/layout/fragment_piano.xml
+++ b/musicdroid/src/main/res/layout/fragment_piano.xml
@@ -34,87 +34,95 @@
         android:id="@+id/oct_button_01_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_c" />
 
     <Button
         android:id="@+id/oct_button_02_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_01_white"
-        android:layout_toEndOf="@+id/oct_button_01_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_d" />
 
     <Button
         android:id="@+id/oct_button_03_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_02_white"
-        android:layout_toEndOf="@+id/oct_button_02_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_e" />
 
     <Button
         android:id="@+id/oct_button_04_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_03_white"
-        android:layout_toEndOf="@+id/oct_button_03_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_f" />
     <Button
         android:id="@+id/oct_button_05_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_04_white"
-        android:layout_toEndOf="@+id/oct_button_04_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_g" />
     <Button
         android:id="@+id/oct_button_06_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_05_white"
-        android:layout_toEndOf="@+id/oct_button_05_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_a" />
     <Button
         android:id="@+id/oct_button_07_white"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toRightOf="@+id/oct_button_06_white"
-        android:layout_toEndOf="@+id/oct_button_06_white"
+        android:background="@drawable/white_selector"
+        android:textColor="@android:color/black"
         android:text="@string/note_name_h" />
 
     <Button
         android:id="@+id/oct_button_01_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="@string/note_name_cis" />
 
     <Button
         android:id="@+id/oct_button_02_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="@string/note_name_dis" />
 
     <Button
         android:id="@+id/oct_button_03_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="" />
 
     <Button
         android:id="@+id/oct_button_04_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="@string/note_name_fis" />
 
     <Button
         android:id="@+id/oct_button_05_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="@string/note_name_gis" />
 
     <Button
         android:id="@+id/oct_button_06_black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/black_selector"
         android:text="@string/note_name_ais" />
 
 </RelativeLayout >


### PR DESCRIPTION
This commit deletes the png-based images which were used to draw the white piano keyboard and replaces them with GradientDrawables as these should scale better for different form factors. Also the geometry of the buttons was adjusted a bit to visually match better with a piano keyboard. Therefore also the UI unit test for button positioning had to be adjusted a bit.
